### PR TITLE
Fix - Show error modal based on app debug config instead of environment

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -63,7 +63,7 @@ return Application::configure(basePath: dirname(__DIR__))
                         ->setStatusCode($statusCode);
                 } else {
                     // Show standard modal for easier debugging locally
-                    if (app()->isLocal() && $statusCode === 500) {
+                    if (app()->hasDebugModeEnabled() && $statusCode === 500) {
                         return $response;
                     }
                     // Return JSON response for PrimeVue toast to display, handled by Inertia router event listener


### PR DESCRIPTION
closes https://github.com/connorabbas/laravel-primevue-starter-kit/issues/371